### PR TITLE
Feature: 캐릭터 스폰 위치 지정 기능 추가

### DIFF
--- a/Assets/Scripts/Court/CourtManager.cs
+++ b/Assets/Scripts/Court/CourtManager.cs
@@ -1,0 +1,138 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class CourtManager : MonoBehaviourPunCallbacks
+{
+    [Header("Court_Testing 씬 설정")]
+    [SerializeField] private Transform player1Position; // 코트 왼쪽 위치
+    [SerializeField] private Transform player2Position; // 코트 오른쪽 위치
+    
+    [Header("자동 찾기")]
+    [SerializeField] private bool autoFindPlayers = true;
+    
+    // 직접 할당용 변수
+    [SerializeField] private GameObject player1;
+    [SerializeField] private GameObject player2;
+    
+    void Start()
+    {
+        // 포지션이 지정되지 않은 경우 기본 위치 생성
+        if (player1Position == null || player2Position == null)
+        {
+            CreatePositionMarkers();
+        }
+        
+        // 플레이어 오브젝트 찾기
+        if (autoFindPlayers)
+        {
+            FindPlayerObjects();
+        }
+        
+        // 플레이어 초기 위치 설정
+        PositionPlayers();
+    }
+    
+    void CreatePositionMarkers()
+    {
+        // 코트 위치 마커 생성
+        GameObject markersHolder = new GameObject("PositionMarkers");
+        
+        // 플레이어 1 포지션 마커 (코트 왼쪽)
+        GameObject p1Marker = new GameObject("Player1Position");
+        p1Marker.transform.parent = markersHolder.transform;
+        p1Marker.transform.position = new Vector3(-9f, 1f, 0f); // 코트 왼쪽 끝
+        player1Position = p1Marker.transform;
+        
+        // 플레이어 2 포지션 마커 (코트 오른쪽)
+        GameObject p2Marker = new GameObject("Player2Position");
+        p2Marker.transform.parent = markersHolder.transform;
+        p2Marker.transform.position = new Vector3(9f, 1f, 0f); // 코트 오른쪽 끝
+        player2Position = p2Marker.transform;
+        
+        Debug.Log("기본 위치 마커가 생성되었습니다.");
+    }
+    
+    void FindPlayerObjects()
+    {
+        // 씬에서 실린더 오브젝트 찾기
+        GameObject[] cylinders = GameObject.FindGameObjectsWithTag("Player");
+        
+        // Player 태그가 없는 경우 Cylinder 형태로 찾기
+        if (cylinders.Length < 2)
+        {
+            cylinders = GameObject.FindObjectsOfType<GameObject>();
+            List<GameObject> foundCylinders = new List<GameObject>();
+            
+            foreach (GameObject obj in cylinders)
+            {
+                if (obj.name.Contains("Cylinder") || 
+                    (obj.GetComponent<MeshFilter>() != null && 
+                     obj.GetComponent<MeshFilter>().sharedMesh != null && 
+                     obj.GetComponent<MeshFilter>().sharedMesh.name.Contains("Cylinder")))
+                {
+                    foundCylinders.Add(obj);
+                }
+            }
+            
+            if (foundCylinders.Count >= 2)
+            {
+                player1 = foundCylinders[0];
+                player2 = foundCylinders[1];
+                Debug.Log("실린더 오브젝트를 플레이어로 찾았습니다.");
+            }
+            else
+            {
+                Debug.LogWarning("씬에서 충분한 실린더 오브젝트를 찾을 수 없습니다!");
+            }
+        }
+        else
+        {
+            player1 = cylinders[0];
+            player2 = cylinders[1];
+            Debug.Log("Player 태그가 있는 오브젝트를 찾았습니다.");
+        }
+    }
+    
+    void PositionPlayers()
+    {
+        // 플레이어 오브젝트가 지정되어 있는지 확인
+        if (player1 == null || player2 == null)
+        {
+            Debug.LogWarning("플레이어 오브젝트가 없습니다!");
+            return;
+        }
+        
+        // 네트워크 환경인 경우 마스터 클라이언트만 설정할 수 있도록 함
+        if (PhotonNetwork.IsConnected && !PhotonNetwork.IsMasterClient)
+        {
+            return;
+        }
+        
+        // 플레이어 1을 왼쪽 위치로 이동
+        player1.transform.position = player1Position.position;
+        
+        // 플레이어 2를 오른쪽 위치로 이동
+        player2.transform.position = player2Position.position;
+        
+        Debug.Log("플레이어 위치가 코트 양 끝으로 설정되었습니다.");
+        
+        // 네트워크 동기화
+        if (PhotonNetwork.IsConnected && photonView != null)
+        {
+            photonView.RPC("SyncPlayerPositions", RpcTarget.Others);
+        }
+    }
+    
+    [PunRPC]
+    void SyncPlayerPositions()
+    {
+        // 다른 클라이언트에서 플레이어 위치 동기화
+        if (player1 != null && player2 != null && player1Position != null && player2Position != null)
+        {
+            player1.transform.position = player1Position.position;
+            player2.transform.position = player2Position.position;
+        }
+    }
+}

--- a/Assets/Scripts/Court/CourtManager.cs.meta
+++ b/Assets/Scripts/Court/CourtManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aa4e1747a9aaaa749b7006adfbbc3372
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/GameManager.cs
+++ b/Assets/Scripts/Gameplay/GameManager.cs
@@ -1,0 +1,149 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+
+public class GameManager : MonoBehaviourPunCallbacks
+{
+    [Header("플레이어 설정")]
+    public Transform player1SpawnPoint; // 플레이어 1 시작 위치
+    public Transform player2SpawnPoint; // 플레이어 2 시작 위치
+    public GameObject playerPrefab; // 플레이어 프리팹 (실린더)
+
+    [Header("현재 씬의 플레이어 오브젝트")]
+    public GameObject player1Object; // 플레이어 1 오브젝트 (실린더)
+    public GameObject player2Object; // 플레이어 2 오브젝트 (실린더)
+
+    void Start()
+    {
+        // 스폰 포인트가 지정되지 않았을 경우 기본값 생성
+        if (player1SpawnPoint == null || player2SpawnPoint == null)
+        {
+            CreateDefaultSpawnPoints();
+        }
+
+        // 플레이어 오브젝트 찾기
+        FindPlayerObjects();
+        
+        // 플레이어 초기 위치 설정
+        PositionPlayers();
+    }
+
+    void CreateDefaultSpawnPoints()
+    {
+        // 기본 스폰 포인트 생성 - 이미지에 보여진 정확한 위치로 설정
+        GameObject spawnPointsHolder = new GameObject("SpawnPoints");
+        
+        // 플레이어 1 스폰 포인트 
+        GameObject p1Spawn = new GameObject("Player1SpawnPoint");
+        p1Spawn.transform.parent = spawnPointsHolder.transform;
+        p1Spawn.transform.position = new Vector3(-1.31f, 1f, -5.81f); // 이미지에 보여진 player1 위치
+        player1SpawnPoint = p1Spawn.transform;
+        
+        // 플레이어 2 스폰 포인트
+        GameObject p2Spawn = new GameObject("Player2SpawnPoint");
+        p2Spawn.transform.parent = spawnPointsHolder.transform;
+        p2Spawn.transform.position = new Vector3(-0.98f, 1f, 10.207f); // 이미지에 보여진 player2 위치
+        player2SpawnPoint = p2Spawn.transform;
+        
+        Debug.Log("플레이어 스폰 포인트가 생성되었습니다.");
+    }
+    
+    void FindPlayerObjects()
+    {
+        // 씬에서 player1과 player2라는 이름의 오브젝트 찾기
+        player1Object = GameObject.Find("player1");
+        player2Object = GameObject.Find("player2");
+        
+        if (player1Object != null && player2Object != null)
+        {
+            Debug.Log("player1과 player2 오브젝트를 찾았습니다.");
+            return;
+        }
+        
+        // 이름으로 찾기 실패한 경우 태그로 시도
+        GameObject[] playerObjects = GameObject.FindGameObjectsWithTag("Player");
+        
+        if (playerObjects.Length >= 2)
+        {
+            player1Object = playerObjects[0];
+            player2Object = playerObjects[1];
+            Debug.Log("Player 태그로 플레이어 오브젝트를 찾았습니다.");
+            return;
+        }
+        
+        // 위의 방법으로 찾지 못한 경우, 실린더 형태를 가진 오브젝트 찾기
+        GameObject[] allObjects = FindObjectsOfType<GameObject>();
+        List<GameObject> potentialPlayers = new List<GameObject>();
+        
+        foreach (GameObject obj in allObjects)
+        {
+            // 이름에 Player나 Cylinder가 포함된 오브젝트 찾기
+            if (obj.name.Contains("Player") || obj.name.Contains("Cylinder") || 
+                obj.name.Contains("player"))
+            {
+                potentialPlayers.Add(obj);
+            }
+            // 또는 실린더 메시를 가진 오브젝트 찾기
+            else if (obj.GetComponent<MeshFilter>() != null && 
+                     obj.GetComponent<MeshFilter>().sharedMesh != null && 
+                     obj.GetComponent<MeshFilter>().sharedMesh.name.Contains("Cylinder"))
+            {
+                potentialPlayers.Add(obj);
+            }
+        }
+        
+        if (potentialPlayers.Count >= 2)
+        {
+            player1Object = potentialPlayers[0];
+            player2Object = potentialPlayers[1];
+            Debug.Log("이름 또는 메시 형태로 플레이어 오브젝트를 찾았습니다.");
+        }
+        else
+        {
+            Debug.LogError("씬에서 충분한 수의 플레이어 오브젝트를 찾을 수 없습니다!");
+        }
+    }
+    
+    void PositionPlayers()
+    {
+        if (player1Object != null && player2Object != null)
+        {
+            // 플레이어 1과 2를 각각의 스폰 포인트로 이동
+            player1Object.transform.position = player1SpawnPoint.position;
+            player2Object.transform.position = player2SpawnPoint.position;
+            
+            Debug.Log("플레이어 위치가 설정되었습니다.");
+        }
+        else
+        {
+            Debug.LogError("플레이어 오브젝트가 설정되지 않았습니다!");
+        }
+    }
+    
+    // 네트워크 환경에서의 플레이어 스폰 방법 (향후 확장용)
+    void SpawnNetworkPlayers()
+    {
+        if (PhotonNetwork.IsConnected)
+        {
+            // 방장인 경우에만 플레이어 위치 설정 권한 부여
+            if (PhotonNetwork.IsMasterClient)
+            {
+                // 네트워크 이벤트를 통해 모든 클라이언트에게 위치 설정 명령 전송
+                photonView.RPC("RPC_SetPlayerPositions", RpcTarget.All);
+            }
+        }
+        else
+        {
+            // 비 네트워크 환경일 경우 바로 위치 설정
+            PositionPlayers();
+        }
+    }
+    
+    [PunRPC]
+    void RPC_SetPlayerPositions()
+    {
+        PositionPlayers();
+    }
+}

--- a/Assets/Scripts/Gameplay/GameManager.cs.meta
+++ b/Assets/Scripts/Gameplay/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2659fbecde12b3640965eb0d40ab2e47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Network/Launcher.cs
+++ b/Assets/Scripts/Network/Launcher.cs
@@ -1,0 +1,55 @@
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+
+public class Launcher : MonoBehaviourPunCallbacks
+{
+    [SerializeField] private GameObject connectingInfoPanel;
+    
+    void Start()
+    {
+        // 게임 시작 시 Photon 서버에 연결
+        ConnectToPhoton();
+    }
+    
+    private void ConnectToPhoton()
+    {
+        // 패널이 있다면 활성화
+        if (connectingInfoPanel) connectingInfoPanel.SetActive(true);
+        
+        // 이미 연결되어 있다면 다시 연결하지 않음
+        if (PhotonNetwork.IsConnected) return;
+        
+        // Photon 서버에 연결
+        PhotonNetwork.ConnectUsingSettings();
+        Debug.Log("Photon 서버에 연결 시도 중...");
+    }
+    
+    // 마스터 서버에 연결되었을 때 호출되는 콜백
+    public override void OnConnectedToMaster()
+    {
+        Debug.Log("Photon 마스터 서버에 연결되었습니다.");
+        
+        // 로비에 참가
+        PhotonNetwork.JoinLobby();
+        Debug.Log("로비 참가 시도 중...");
+    }
+    
+    // 로비 참가 성공 시 호출되는 콜백
+    public override void OnJoinedLobby()
+    {
+        Debug.Log("로비 참가 성공!");
+        
+        // 패널이 있다면 비활성화
+        if (connectingInfoPanel) connectingInfoPanel.SetActive(false);
+    }
+    
+    // 연결 실패 시 호출되는 콜백
+    public override void OnDisconnected(DisconnectCause cause)
+    {
+        Debug.LogWarning($"Photon 서버와 연결이 끊어졌습니다. 이유: {cause}");
+        
+        // 패널이 있다면 비활성화
+        if (connectingInfoPanel) connectingInfoPanel.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Player/PlayerSetup.cs
+++ b/Assets/Scripts/Player/PlayerSetup.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using Photon.Realtime;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlayerSetup : MonoBehaviourPunCallbacks
+{
+    [Header("플레이어 설정")]
+    public bool isPlayerOne = false; // true면 player1, false면 player2
+    
+    [Header("스폰 위치")]
+    public Vector3 player1Position = new Vector3(-9f, 1f, 0f); // 코트 왼쪽 끝
+    public Vector3 player2Position = new Vector3(9f, 1f, 0f);  // 코트 오른쪽 끝
+
+    private Rigidbody rb;
+
+    void Awake()
+    {
+        rb = GetComponent<Rigidbody>();
+    }
+
+    void Start()
+    {
+        // 게임 시작 시 플레이어를 자기 위치로 이동
+        SetInitialPosition();
+    }
+
+    void SetInitialPosition()
+    {
+        // 네트워크에 연결된 경우
+        if (PhotonNetwork.IsConnected)
+        {
+            // 액터 번호에 따라 플레이어 결정 (1번이 player1, 2번이 player2)
+            isPlayerOne = photonView.Owner.ActorNumber == 1;
+        }
+        
+        // 플레이어 타입에 따라 위치 설정
+        if (isPlayerOne)
+        {
+            transform.position = player1Position;
+            Debug.Log("Player 1이 왼쪽 위치에 배치되었습니다.");
+        }
+        else
+        {
+            transform.position = player2Position;
+            Debug.Log("Player 2가 오른쪽 위치에 배치되었습니다.");
+        }
+        
+        // 위치 이동 후 물리 시뮬레이션 안정화
+        if (rb != null)
+        {
+            rb.velocity = Vector3.zero;
+            rb.angularVelocity = Vector3.zero;
+        }
+    }
+    
+    // 네트워크에서 플레이어가 참가했을 때 호출
+    public override void OnJoinedRoom()
+    {
+        SetInitialPosition();
+    }
+}

--- a/Assets/Scripts/Player/PlayerSetup.cs.meta
+++ b/Assets/Scripts/Player/PlayerSetup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b65904a83c093d246bd24e2b9d853a44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### CourtManager.cs (Assets/Scripts/Court/)
Court_Testing 씬을 위한 가장 직접적인 솔루션입니다
씬에서 실린더 오브젝트를 자동으로 찾아서 코트 양쪽 끝에 배치합니다
Unity 에디터에서 실린더 오브젝트를 직접 할당할 수도 있습니다
필요한 경우 Photon 네트워크 기능도 포함되어 있습니다
### GameManager.cs (Assets/Scripts/Gameplay/)
더 일반적인 게임 매니저 스크립트로 플레이어 위치 설정을 관리합니다
스폰 포인트를 생성하고 플레이어를 해당 위치에 배치합니다
여러 방법으로 씬에서 플레이어 오브젝트를 자동 검색합니다
### PlayerSetup.cs (Assets/Scripts/Player/)
각 플레이어 오브젝트에 직접 추가하는 컴포넌트입니다
플레이어가 player1인지 player2인지에 따라 위치를 설정합니다
Photon 네트워크에서 플레이어 번호에 따라 자동으로 위치를 지정합니다